### PR TITLE
Update service account Firestore rule

### DIFF
--- a/infra/firestore/firestore.rules
+++ b/infra/firestore/firestore.rules
@@ -11,7 +11,8 @@ service cloud.firestore {
     function isServiceAccount() {
       return request.auth != null &&
              request.auth.token.email != null &&
-             request.auth.token.email.matches('.*\\.gserviceaccount\\.com$');
+             // Allows service principals like worker@project.iam.gserviceaccount.com while excluding regular users.
+             request.auth.token.email.matches('.*@.*\.gserviceaccount\.com$');
     }
 
     match /events/{documentId} {


### PR DESCRIPTION
## Summary
- tighten the `isServiceAccount` helper so it matches standard `@*.gserviceaccount.com` principals
- document the intended service account behavior directly in the rules file

## Testing
- not run (firebase CLI is unavailable in the execution environment; installing `firebase-tools` from npm returned HTTP 403)


------
https://chatgpt.com/codex/tasks/task_e_68cb18ac4ae8832e9471757c0818ec54