### PR TITLE
Add helloWorld Cloud Function and local testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # recovery-engine
-Recovery Engine
+
+## Lokales Testing der Hello-World-Funktion
+
+1. Abhängigkeiten installieren (falls noch nicht geschehen):
+   ```bash
+   cd infra/functions
+   npm install
+   ```
+2. Firebase Emulator für Functions und Firestore starten:
+   ```bash
+   npx firebase emulators:start --only functions,firestore --project recovery-engine
+   ```
+3. In einem zweiten Terminal die Funktion aufrufen (Standard-Port 5001):
+   ```bash
+   curl http://127.0.0.1:5001/recovery-engine/europe-west1/helloWorld
+   ```
+   Als Antwort sollte `{ "message": "Hello World" }` zurückgegeben werden. Zusätzlich wird das Dokument `demo/hello` in der Emulator-Firestore-Datenbank erstellt bzw. aktualisiert.
+
+## Optionale Deployment-Notiz
+
+Für ein Deployment ins GCP-Projekt kann folgende CLI genutzt werden:
+```bash
+cd infra/functions
+npx firebase deploy --only functions:helloWorld --project recovery-engine
+```
+
+## Firestore Security Tests
 
 Run the Firestore emulator with `firebase emulators:start --only firestore` to validate the security rules.
-Use the auth payload `{"uid":"tenant-user","token":{"tenantId":"demo-tenant"}}` for tenant read simulations.
-Service accounts can be tested with `{"uid":"svc","token":{"email":"worker@project.iam.gserviceaccount.com"}}`.
+Use the auth payload `{ "uid":"tenant-user","token":{"tenantId":"demo-tenant"}}` for tenant read simulations.
+Service accounts can be tested with `{ "uid":"svc","token":{"email":"worker@project.iam.gserviceaccount.com"}}`.

--- a/infra/functions/index.js
+++ b/infra/functions/index.js
@@ -15,6 +15,30 @@ async function writeDoc(tenant,col,obj){
   return admin.firestore().collection("tenants").doc(tenant).collection(col).add({tenantId:tenant,...obj});
 }
 
+exports.helloWorld = onRequest(async (req, res) => {
+  try {
+    if (req.method !== "GET" && req.method !== "POST") {
+      res.set("Allow", ["GET", "POST"]);
+      throw new HttpsError("invalid-argument", "Only GET and POST supported");
+    }
+
+    const docRef = admin.firestore().collection("demo").doc("hello");
+    const payload = { message: "Hello World" };
+
+    await docRef.set(payload);
+    const snapshot = await docRef.get();
+
+    if (!snapshot.exists) {
+      throw new HttpsError("internal", "Document not found after write");
+    }
+
+    res.status(200).json(snapshot.data());
+  } catch (error) {
+    const statusCode = error.httpErrorCode?.status || 500;
+    res.status(statusCode).json({ error: error.message });
+  }
+});
+
 exports.ingestEvent = onRequest(async (req,res)=>{
   try{ if(req.method!=="POST") throw new HttpsError("invalid-argument","POST");
        const tenant=authz(req);


### PR DESCRIPTION
## Summary
- add an HTTP Cloud Function that writes and reads demo/hello in Firestore
- return the Hello World payload in the response body
- document how to run the Firebase Emulator Suite and optionally deploy the function

## Testing
- node -e "require('./infra/functions/index.js')"

------
https://chatgpt.com/codex/tasks/task_e_68cc72ed808c832e89d6aebc6bb8911b