### PR TITLE
feat: add timestamp to hello world payload

### DIFF
--- a/infra/functions/index.js
+++ b/infra/functions/index.js
@@ -23,7 +23,8 @@ exports.helloWorld = onRequest(async (req, res) => {
     }
 
     const docRef = admin.firestore().collection("demo").doc("hello");
-    const payload = { message: "Hello World" };
+    const ts = new Date().toISOString();
+    const payload = { message: "Hello World", ts };
 
     await docRef.set(payload);
     const snapshot = await docRef.get();


### PR DESCRIPTION
## Summary
- add an ISO-8601 timestamp to the helloWorld response payload
- persist the timestamp together with the message in Firestore before returning it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc8ac69540832eb794f624e47dfd43