### PR TITLE
feat: add timestamp to helloWorld response

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,7 +3,12 @@ const admin = require('firebase-admin');
 admin.apps.length ? admin.app() : admin.initializeApp();
 exports.helloWorld = functions.region('europe-west1').https.onRequest(async (_req, res) => {
   const db = admin.firestore();
-  await db.collection('demo').doc('hello').set({ message: 'Hello World' });
-  const doc = await db.collection('demo').doc('hello').get();
+  const payload = {
+    message: 'Hello World',
+    ts: new Date().toISOString(),
+  };
+  const docRef = db.collection('demo').doc('hello');
+  await docRef.set(payload);
+  const doc = await docRef.get();
   res.status(200).json(doc.data());
 });


### PR DESCRIPTION
## Summary
- add ISO-8601 timestamp generation for the helloWorld response
- persist the same payload to Firestore before responding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0531f35fc832eb6d8773b0b2daaeb