### PR TITLE
Add GitHub Actions smoke test for helloWorld emulator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,68 @@
-﻿name: ci
-on: [pull_request]
+name: smoke
+
+on:
+  pull_request:
+    branches:
+      - main
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: '22' }
-      - run: npm ci --prefix functions
-      - run: echo "TODO: add emulator smoke" 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install Functions dependencies
+        run: npm ci --prefix functions
+
+      - name: Start Firebase emulators
+        run: |
+          nohup npx firebase-tools emulators:start \
+            --only functions,firestore \
+            --project recovery-engine \
+            > firebase-emulator.log 2>&1 &
+          EMULATOR_PID=$!
+          echo "Firebase emulators started with PID ${EMULATOR_PID}"
+          echo "EMULATOR_PID=${EMULATOR_PID}" >> "$GITHUB_ENV"
+
+      - name: Wait for Functions emulator (port 5001)
+        run: |
+          timeout 120 bash -c 'until nc -z 127.0.0.1 5001; do sleep 2; done'
+
+      - name: Run smoke test
+        env:
+          GCLOUD_PROJECT: recovery-engine
+          GOOGLE_CLOUD_PROJECT: recovery-engine
+          FIRESTORE_EMULATOR_HOST: 127.0.0.1:8080
+          FUNCTIONS_EMULATOR_HOST: http://127.0.0.1:5001
+        run: npm run test:emu --prefix functions
+
+      - name: Dump emulator logs on failure
+        if: failure()
+        run: |
+          if [ -f firebase-emulator.log ]; then
+            echo '===== firebase-emulator.log ====='
+            cat firebase-emulator.log
+            echo '===== end of firebase-emulator.log ====='
+          else
+            echo 'firebase-emulator.log not found'
+          fi
+
+      - name: Stop Firebase emulators
+        if: always()
+        run: |
+          if [ -n "${{ env.EMULATOR_PID }}" ] && ps -p "${{ env.EMULATOR_PID }}" > /dev/null 2>&1; then
+            echo "Stopping Firebase emulators (PID=${{ env.EMULATOR_PID }})"
+            kill "${{ env.EMULATOR_PID }}" || true
+            sleep 5
+          else
+            echo 'Firebase emulator process not running.'
+          fi

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "engines": { "node": "22" },
   "scripts": {
-    "emu": "firebase emulators:start --only functions,firestore --project recovery-engine"
+    "emu": "firebase emulators:start --only functions,firestore --project recovery-engine",
+    "test:emu": "node scripts/emu-smoke.js"
   },
   "dependencies": {
     "firebase-admin": "^12.6.0",

--- a/functions/scripts/emu-smoke.js
+++ b/functions/scripts/emu-smoke.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+'use strict';
+
+const REQUIRED_ENV_VARS = [
+  'GCLOUD_PROJECT',
+  'GOOGLE_CLOUD_PROJECT',
+  'FIRESTORE_EMULATOR_HOST'
+];
+
+function ensureNodeVersion() {
+  const major = Number.parseInt(process.versions.node.split('.')[0], 10);
+  if (Number.isNaN(major) || major < 18) {
+    throw new Error(`Node.js >= 18 is required to run the smoke test (detected ${process.versions.node}).`);
+  }
+}
+
+function ensureEnvironment() {
+  const missing = REQUIRED_ENV_VARS.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    throw new Error(`Missing required environment variables for emulator smoke test: ${missing.join(', ')}`);
+  }
+}
+
+function resolveBaseUrl() {
+  const host = process.env.FUNCTIONS_EMULATOR_HOST ?? '127.0.0.1:5001';
+  const normalizedHost = host.startsWith('http://') || host.startsWith('https://') ? host : `http://${host}`;
+  const trimmed = normalizedHost.endsWith('/') ? normalizedHost : `${normalizedHost}/`;
+  return trimmed;
+}
+
+function validateResponsePayload(payload) {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    throw new Error('Expected response payload to be a JSON object.');
+  }
+
+  if (typeof payload.message !== 'string' || payload.message.length === 0) {
+    throw new Error('Expected "message" to be a non-empty string.');
+  }
+
+  if (typeof payload.ts !== 'string') {
+    throw new Error('Expected "ts" to be a string.');
+  }
+
+  const parsed = new Date(payload.ts);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('The "ts" field is not a valid ISO-8601 timestamp.');
+  }
+
+  if (parsed.toISOString() !== payload.ts) {
+    throw new Error('The "ts" field must be a canonical ISO-8601 string (e.g. produced by Date.toISOString()).');
+  }
+}
+
+async function main() {
+  ensureNodeVersion();
+  ensureEnvironment();
+
+  const baseUrl = resolveBaseUrl();
+  const endpointPath = 'recovery-engine/europe-west1/helloWorld';
+  const url = new URL(endpointPath, baseUrl).toString();
+
+  console.log(`Running smoke test against ${url}`);
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json'
+    },
+    signal: AbortSignal.timeout(10000)
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Unexpected response status ${response.status}: ${body}`);
+  }
+
+  const payload = await response.json();
+  validateResponsePayload(payload);
+
+  console.log('Smoke test passed ✅');
+}
+
+main().catch((error) => {
+  console.error('Smoke test failed ❌');
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Node.js smoke test script that validates the helloWorld emulator response
- expose an npm script for running the smoke test locally or in CI
- configure a GitHub Actions workflow that boots Firebase emulators and runs the smoke test on pull requests

## Testing
- not run (emulator startup requires CI context)


------
https://chatgpt.com/codex/tasks/task_e_68d05a28d3c8832e9f765a50c9de4ae6