### PR TITLE
Add lostRevenueMock HTTP endpoint

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,7 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.apps.length ? admin.app() : admin.initializeApp();
+
 exports.helloWorld = functions.region('europe-west1').https.onRequest(async (_req, res) => {
   const db = admin.firestore();
   const payload = {
@@ -12,3 +13,12 @@ exports.helloWorld = functions.region('europe-west1').https.onRequest(async (_re
   const doc = await docRef.get();
   res.status(200).json(doc.data());
 });
+
+exports.lostRevenueMock = functions
+  .region('europe-west1')
+  .https.onRequest((_req, res) => {
+    res.status(200).json({
+      lostRevenue: 1234,
+      ts: new Date().toISOString(),
+    });
+  });


### PR DESCRIPTION
## Summary
- add a new europe-west1 HTTPS function `lostRevenueMock` that returns a fixed lost revenue payload with the current timestamp

## Testing
- `npm --prefix functions run test:emu` *(fails: missing emulator environment variables in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d069c98f54832e91fbd24d279b3d6b