### PR TITLE
AT-004 add logging for HTTP functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,7 +2,20 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.apps.length ? admin.app() : admin.initializeApp();
 
-exports.helloWorld = functions.region('europe-west1').https.onRequest(async (_req, res) => {
+exports.helloWorld = functions.region('europe-west1').https.onRequest(async (req, res) => {
+  const timestamp = new Date().toISOString();
+  let serializedPayload;
+
+  try {
+    serializedPayload = JSON.stringify(req.body ?? null);
+  } catch (_error) {
+    serializedPayload = '"[unserializable payload]"';
+  }
+
+  console.log(
+    `[AT-004] Function helloWorld called at ${timestamp}, payload: ${serializedPayload}`
+  );
+
   const db = admin.firestore();
   const payload = {
     message: 'Hello World',
@@ -16,7 +29,20 @@ exports.helloWorld = functions.region('europe-west1').https.onRequest(async (_re
 
 exports.lostRevenueMock = functions
   .region('europe-west1')
-  .https.onRequest((_req, res) => {
+  .https.onRequest((req, res) => {
+    const timestamp = new Date().toISOString();
+    let serializedPayload;
+
+    try {
+      serializedPayload = JSON.stringify(req.body ?? null);
+    } catch (_error) {
+      serializedPayload = '"[unserializable payload]"';
+    }
+
+    console.log(
+      `[AT-004] Function lostRevenueMock called at ${timestamp}, payload: ${serializedPayload}`
+    );
+
     res.status(200).json({
       lostRevenue: 1234,
       ts: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add timestamped logging to the helloWorld and lostRevenueMock HTTP functions to capture request payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d06fca269c832eae6dafc98110b821