### PR TITLE
Add eventWriteMock endpoint

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -48,3 +48,20 @@ exports.lostRevenueMock = functions
       ts: new Date().toISOString(),
     });
   });
+
+exports.eventWriteMock = functions
+  .region('europe-west1')
+  .https.onRequest(async (_req, res) => {
+    const db = admin.firestore();
+    const payload = {
+      type: 'test',
+      ts: new Date().toISOString(),
+    };
+
+    const docRef = await db.collection('events').add(payload);
+
+    res.status(200).json({
+      id: docRef.id,
+      ...payload,
+    });
+  });


### PR DESCRIPTION
## Summary
- add eventWriteMock HTTP function that writes a mock event document to Firestore
- return the stored document id and payload in the HTTP response

## Testing
- `npm --prefix functions run test:emu` *(fails: Missing required environment variables for emulator smoke test: GCLOUD_PROJECT, GOOGLE_CLOUD_PROJECT, FIRESTORE_EMULATOR_HOST)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e71319fc832e83db43f3d6422695