### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/functions/health/index.js
+++ b/functions/health/index.js
@@ -1,0 +1,7 @@
+const functions = require('firebase-functions');
+
+module.exports = functions
+  .region('europe-west1')
+  .https.onRequest((_req, res) => {
+    res.status(200).json({ ok: true });
+  });

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,8 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 admin.apps.length ? admin.app() : admin.initializeApp();
 
+exports.health = require('./health');
+
 exports.helloWorld = functions.region('europe-west1').https.onRequest(async (req, res) => {
   const timestamp = new Date().toISOString();
   let serializedPayload;


### PR DESCRIPTION
## Summary
- add a dedicated `health` Cloud Function that responds with `{ ok: true }`
- export the health endpoint from the main functions entrypoint

## Testing
- npm --prefix functions run emu *(fails: `firebase` CLI is not available in the environment)*
- curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:5001/recovery-engine/europe-west1/health *(blocked by missing emulator)*

------
https://chatgpt.com/codex/tasks/task_e_68d134c46748832e91d327d8c26be8cd