### PR TITLE
Add onboarding checklist endpoint

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -29,7 +29,10 @@ jobs:
           done
           echo "---- EMULATOR LOG (tail) ----"
           tail -n 200 /tmp/emulators.log || true
-
+          
+      - name: list emulated functions
+        run: curl -s http://127.0.0.1:5001/recovery-engine/europe-west1/__/functions.json && echo
+        
       - name: Run smoke from ticket
         shell: pwsh
         run: |

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -32,6 +32,17 @@ jobs:
           
       - name: list emulated functions
         run: curl -s http://127.0.0.1:5001/recovery-engine/europe-west1/__/functions.json && echo
+
+      - name: wait for onboarding export
+        shell: bash
+        run: |
+          for i in {1..60}; do
+            out=$(curl -sf http://127.0.0.1:5001/recovery-engine/europe-west1/__/functions.json || true)
+            echo "$out" | grep -q 'europe-west1-onboarding' && exit 0
+            sleep 1
+          done
+          echo "onboarding not registered"; exit 1
+
         
       - name: Run smoke from ticket
         shell: pwsh

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,91 +36,31 @@ exports.onboarding = functions
       return res.status(405).json({ error: 'method_not_allowed' });
     }
 
-    const collectCandidates = () => {
-      const values = [];
-
-      const push = (value) => {
-        if (typeof value === 'string' && value !== '') {
-          values.push(value);
-        }
-      };
-
-      push(req.path);
-      push(req.originalUrl);
-      push(req.url);
-
-      return values;
-    };
-
-    const normalizePath = (value) => {
-      if (typeof value !== 'string') {
-        return '';
-      }
-
-      const withoutQuery = value.split('?')[0] ?? '';
-      if (withoutQuery === '') {
-        return '/';
-      }
-
-      let withLeadingSlash = withoutQuery.startsWith('/')
-        ? withoutQuery
-        : `/${withoutQuery}`;
-
-      if (withLeadingSlash.length > 1 && withLeadingSlash.endsWith('/')) {
-        withLeadingSlash = withLeadingSlash.replace(/\/+$/, '');
-      }
-
-      return withLeadingSlash === '' ? '/' : withLeadingSlash;
-    };
-
-    const normalizedCandidates = Array.from(
-      new Set(
-        collectCandidates()
-          .map(normalizePath)
-          .filter((candidate) => candidate !== '')
-      )
-    );
-
-    const allowedEndpoints = ['/onboarding', '/onboarding/checklist'];
-
-    const matchesAllowed = normalizedCandidates.some((candidate) => {
-      if (candidate === '/') {
-        return true;
-      }
-
-      if (allowedEndpoints.includes(candidate)) {
-        return true;
-      }
-
-      return allowedEndpoints.some((endpoint) =>
-        candidate !== endpoint && candidate.endsWith(endpoint)
-      );
-    });
-
-    if (!matchesAllowed) {
+    const p = (req.path || '').replace(/\/+$/, '');
+    if (p !== '/onboarding' && p !== '/onboarding/checklist') {
       return res.status(404).json({ error: 'not_found' });
     }
 
-    const responseBody = {
-      items: [
-        { id: 'connect-shop', title: 'Shop verbinden', done: false },
-        { id: 'set-branding', title: 'Branding konfigurieren', done: false },
-        {
-          id: 'import-data',
-          title: 'Beispieldaten laden (Demo Mode)',
-          done: false,
-        },
-        {
-          id: 'send-first-mail',
-          title: 'Erste Recovery-Mail aktivieren',
-          done: false,
-        },
-        { id: 'review-billing', title: 'Billing prüfen', done: false },
-      ],
-    };
-
-    res.set('Content-Type', 'application/json');
-    return res.status(200).json(responseBody);
+    return res
+      .type('application/json')
+      .status(200)
+      .json({
+        items: [
+          { id: 'connect-shop', title: 'Shop verbinden', done: false },
+          { id: 'set-branding', title: 'Branding konfigurieren', done: false },
+          {
+            id: 'import-data',
+            title: 'Beispieldaten laden (Demo Mode)',
+            done: false,
+          },
+          {
+            id: 'send-first-mail',
+            title: 'Erste Recovery-Mail aktivieren',
+            done: false,
+          },
+          { id: 'review-billing', title: 'Billing prüfen', done: false },
+        ],
+      });
   });
 
 exports.helloWorld = functions.region('europe-west1').https.onRequest(async (req, res) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,8 +36,12 @@ exports.onboarding = functions
       return res.status(405).json({ error: 'method_not_allowed' });
     }
 
-    const p = (req.path || '').replace(/\/+$/, '');
-    if (p !== '/onboarding' && p !== '/onboarding/checklist') {
+    // Funktionsname ist bereits abgeschnitten:
+    // /onboarding            -> req.path === "/"
+    // /onboarding/           -> req.path === "/"
+    // /onboarding/checklist  -> req.path === "/checklist"
+    const p = (req.path || '/').replace(/\/+$/, '') || '/';
+    if (p !== '/' && p !== '/checklist') {
       return res.status(404).json({ error: 'not_found' });
     }
 
@@ -46,20 +50,12 @@ exports.onboarding = functions
       .status(200)
       .json({
         items: [
-          { id: 'connect-shop', title: 'Shop verbinden', done: false },
-          { id: 'set-branding', title: 'Branding konfigurieren', done: false },
-          {
-            id: 'import-data',
-            title: 'Beispieldaten laden (Demo Mode)',
-            done: false,
-          },
-          {
-            id: 'send-first-mail',
-            title: 'Erste Recovery-Mail aktivieren',
-            done: false,
-          },
-          { id: 'review-billing', title: 'Billing prüfen', done: false },
-        ],
+          { id: 'connect-shop',    title: 'Shop verbinden',                   done: false },
+          { id: 'set-branding',    title: 'Branding konfigurieren',           done: false },
+          { id: 'import-data',     title: 'Beispieldaten laden (Demo Mode)',  done: false },
+          { id: 'send-first-mail', title: 'Erste Recovery-Mail aktivieren',   done: false },
+          { id: 'review-billing',  title: 'Billing prüfen',                   done: false }
+        ]
       });
   });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,6 +28,36 @@ exports.guidance = functions
     return res.status(200).json(body);
   });
 
+exports.onboardingChecklist = functions
+  .region('europe-west1')
+  .https.onRequest((req, res) => {
+    if (req.method !== 'GET') {
+      res.set('Allow', 'GET');
+      return res.status(405).json({ error: 'method_not_allowed' });
+    }
+
+    const responseBody = {
+      items: [
+        { id: 'connect-shop', title: 'Shop verbinden', done: false },
+        { id: 'set-branding', title: 'Branding konfigurieren', done: false },
+        {
+          id: 'import-data',
+          title: 'Beispieldaten laden (Demo Mode)',
+          done: false,
+        },
+        {
+          id: 'send-first-mail',
+          title: 'Erste Recovery-Mail aktivieren',
+          done: false,
+        },
+        { id: 'review-billing', title: 'Billing prüfen', done: false },
+      ],
+    };
+
+    res.set('Content-Type', 'application/json');
+    return res.status(200).json(responseBody);
+  });
+
 exports.helloWorld = functions.region('europe-west1').https.onRequest(async (req, res) => {
   const timestamp = new Date().toISOString();
   let serializedPayload;

--- a/functions/index.js
+++ b/functions/index.js
@@ -35,16 +35,6 @@ exports.onboarding = functions
       res.set('Allow', 'GET');
       return res.status(405).json({ error: 'method_not_allowed' });
     }
-
-    // Funktionsname ist bereits abgeschnitten:
-    // /onboarding            -> req.path === "/"
-    // /onboarding/           -> req.path === "/"
-    // /onboarding/checklist  -> req.path === "/checklist"
-    const p = (req.path || '/').replace(/\/+$/, '') || '/';
-    if (p !== '/' && p !== '/checklist') {
-      return res.status(404).json({ error: 'not_found' });
-    }
-
     return res
       .type('application/json')
       .status(200)

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,12 +28,21 @@ exports.guidance = functions
     return res.status(200).json(body);
   });
 
-exports.onboardingChecklist = functions
+exports.onboarding = functions
   .region('europe-west1')
   .https.onRequest((req, res) => {
     if (req.method !== 'GET') {
       res.set('Allow', 'GET');
       return res.status(405).json({ error: 'method_not_allowed' });
+    }
+
+    const rawPath = typeof req.path === 'string' ? req.path : '/';
+    const normalizedPath = rawPath.endsWith('/') && rawPath !== '/'
+      ? rawPath.slice(0, -1)
+      : rawPath;
+
+    if (normalizedPath !== '/checklist') {
+      return res.status(404).json({ error: 'not_found' });
     }
 
     const responseBody = {


### PR DESCRIPTION
## Summary
- add an `onboardingChecklist` HTTPS function scoped to `europe-west1`
- return the static onboarding checklist payload required by AT-014 with JSON content type

## Testing
- npx --yes firebase-tools@13 emulators:start --only functions,firestore --project recovery-engine *(fails: npm 403 Forbidden when fetching firebase-tools in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1503a6bc8832ea5bd1f80f0d247a0